### PR TITLE
Fix drawing through semi-transparent materials and on skybox

### DIFF
--- a/lua/tanktracktool/client/render/mode.lua
+++ b/lua/tanktracktool/client/render/mode.lua
@@ -24,7 +24,8 @@ local draws, emptyCSENT = tanktracktool.render.draws, tanktracktool.render.empty
 local eyepos, eyedir = Vector(), Vector()
 local flashlightMODE
 
-hook.Add( "PostDrawOpaqueRenderables", "tanktracktoolRenderDraw", function()
+hook.Add( "PostDrawOpaqueRenderables", "tanktracktoolRenderDraw", function(bDrawingDepth, bDrawingSkybox)
+    if bDrawingDepth or bDrawingSkybox then return end
     flashlightMODE = LocalPlayer():FlashlightIsOn() --or #ents.FindByClass "*projectedtexture*" ~= 0
     eyepos = EyePos()
     eyedir = EyeVector()

--- a/lua/tanktracktool/client/render/mode.lua
+++ b/lua/tanktracktool/client/render/mode.lua
@@ -24,8 +24,8 @@ local draws, emptyCSENT = tanktracktool.render.draws, tanktracktool.render.empty
 local eyepos, eyedir = Vector(), Vector()
 local flashlightMODE
 
-hook.Add( "PostDrawOpaqueRenderables", "tanktracktoolRenderDraw", function(bDrawingDepth, bDrawingSkybox)
-    if bDrawingDepth or bDrawingSkybox then return end
+hook.Add( "PostDrawOpaqueRenderables", "tanktracktoolRenderDraw", function(bDrawingDepth, _, isDraw3DSkybox)
+    if bDrawingDepth or isDraw3DSkybox then return end
     flashlightMODE = LocalPlayer():FlashlightIsOn() --or #ents.FindByClass "*projectedtexture*" ~= 0
     eyepos = EyePos()
     eyedir = EyeVector()

--- a/lua/tanktracktool/client/render/mode.lua
+++ b/lua/tanktracktool/client/render/mode.lua
@@ -24,7 +24,7 @@ local draws, emptyCSENT = tanktracktool.render.draws, tanktracktool.render.empty
 local eyepos, eyedir = Vector(), Vector()
 local flashlightMODE
 
-hook.Add( "PostDrawTranslucentRenderables", "tanktracktoolRenderDraw", function()
+hook.Add( "PostDrawOpaqueRenderables", "tanktracktoolRenderDraw", function()
     flashlightMODE = LocalPlayer():FlashlightIsOn() --or #ents.FindByClass "*projectedtexture*" ~= 0
     eyepos = EyePos()
     eyedir = EyeVector()


### PR DESCRIPTION
- Fix semi-transparent materials (such as smoke grenades) not affecting tank tracks by moving to PostDrawOpaqueRenderables instead of PostDrawTranslucentRenderables
- Fix duplicate skybox draws on maps where the 3d skybox is too close to the playable area by returning if the draw hook is rendering depth or the skybox