### PR TITLE
Set netvar table if it doesnt exist

### DIFF
--- a/lua/tanktracktool/netvar.lua
+++ b/lua/tanktracktool/netvar.lua
@@ -189,6 +189,7 @@ else
         local size = net.ReadUInt( 32 )
         local data = net.ReadData( size )
 
+        ent.netvar = ent.netvar or {}
         ent.netvar.values = util.JSONToTable( util.Decompress( data ) )
         ent:netvar_callback( "netvar_syncData", ent.netvar.values )
 


### PR DESCRIPTION
Aims to fix
```
[ERROR] lua/tanktracktool/netvar.lua:192: attempt to index field 'netvar' (a nil value)
  1. func - lua/tanktracktool/netvar.lua:192
   2. unknown - lua/includes/extensions/net.lua:38
```
We've been having this error a lot on several different servers:
![image](https://github.com/shadowscion/TankTrackTool/assets/69946827/61964ba2-bd7e-4f37-8457-151a4b297ff6)
![image](https://github.com/shadowscion/TankTrackTool/assets/69946827/74073e4b-dae8-4468-85a2-5a59c3564f33)


I haven't been able to reliably recreate this error so this fix might not be the best, if you have a better way to fix it feel free to do so and close this PR.